### PR TITLE
SP-12751: Generate proper capnproto message for SensorData with SensorSettingRaw field

### DIFF
--- a/bluetooth_mesh/messages/capnproto/generator.py
+++ b/bluetooth_mesh/messages/capnproto/generator.py
@@ -91,6 +91,14 @@ def convert(
         for key, subcon in con.cases.items():
             field_name = type(key)(key).name if isinstance(key, IntEnum) else key
             convert(subcon, visitor, field_name=field_name, message_name=message_name)
+        if con.default is not Pass and getattr(con, "name_for_default", None):
+            convert(
+                con.default,
+                visitor,
+                field_name=con.name_for_default,
+                struct_name=struct_name,
+                message_name=message_name,
+            )
 
         visitor.exit()
 

--- a/bluetooth_mesh/messages/properties.py
+++ b/bluetooth_mesh/messages/properties.py
@@ -749,11 +749,6 @@ PropertyDict = {
     PropertyID.ACTIVE_POWER_LOAD_SIDE: Power,
 }
 
-PropertyValue = Switch(
-    this.sensor_setting_property_id,
-    PropertyDict,
-    default=Array(this.length, Byte)
-)
 
 
 class PropertyMixin:

--- a/bluetooth_mesh/messages/util.py
+++ b/bluetooth_mesh/messages/util.py
@@ -474,6 +474,12 @@ class IfThenElseDefault(IfThenElse):
         return self.thensubcon._parsereport(stream, context, path) if condfunc else self.default
 
 
+class SwitchWithNamedDefault(Switch):
+    def __init__(self, keyfunc, cases, default=None, name_for_default=None):
+        self.name_for_default = name_for_default
+        super().__init__(keyfunc, cases, default)
+
+
 def camelcase(field_name):
     if field_name is None:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bluetooth-mesh-messages"
-version = "0.9.2"
+version = "0.9.3"
 readme = "README.rst"
 authors = [
     { name = "Michał Lowas-Rzechonek", email = "michal.lowas-rzechonek@silvair.com" },

--- a/tests/test_capnproto.py
+++ b/tests/test_capnproto.py
@@ -118,6 +118,7 @@ valid = [
     bytes.fromhex("52" + "220b2003"),  # SENSOR_STATUS
     bytes.fromhex("52" + "440da244ff"),  # SENSOR_STATUS
     bytes.fromhex("52" + "44" + "0da2" + "44ff" + "220b2003"),  # SENSOR_STATUS
+    bytes.fromhex("52" + "09" + "9040" + "a244" + "ff0000"),  # SENSOR_STATUS
     bytes.fromhex("58" + "3000" + "0100" + "0400" + "0900"),  # SENSOR_SETTINGS_STATUS
     bytes.fromhex("58" + "3000"),  # SENSOR_SETTINGS_STATUS
     bytes.fromhex("59" + "5700" + "5700" + "c800"),  # SENSOR_SETTING_SET
@@ -470,13 +471,6 @@ valid = [
     bytes.fromhex("E93601" + "0B" + "8BFF04030201"),  # ELT_PROPERTY_STATUS
 ]
 
-xfailing = [
-    (
-        bytes.fromhex("52" + "09" + "9040" + "a244" + "ff0000"),
-        "capnproto schema fails to parse dict with sensorStatusRaw field",
-    ),  # SENSOR_STATUS
-]
-
 
 @pytest.fixture(scope="session")
 def capnproto():
@@ -491,11 +485,7 @@ def capnproto():
 
 
 @pytest.mark.skipif(not importlib.util.find_spec("capnp"), reason="requires Python3.7")
-@pytest.mark.parametrize(
-    "encoded",
-    [pytest.param(i, id=i.hex()) for i in valid]
-    + [pytest.param(i, id=i.hex(), marks=[pytest.mark.xfail(reason=reason)]) for i, reason in xfailing],
-)
+@pytest.mark.parametrize("encoded", [pytest.param(i, id=i.hex()) for i in valid])
 def test_parse_capnproto(encoded, capnproto):
     logging.info("MESH[%i] %s", len(encoded), encoded.hex())
 


### PR DESCRIPTION
Add support for unknown properties in SensorStatus messages.
- Added a new field `sensorSettingRaw` in the capnproto schema to handle unknown properties (e.g., vendor-specific properties) in SensorStatus messages.
- Updated the capnproto generator to include this new field