### PR TITLE
SP-12778: Reorder AccessMessage opcodes

### DIFF
--- a/bluetooth_mesh/messages/__init__.py
+++ b/bluetooth_mesh/messages/__init__.py
@@ -37,7 +37,6 @@ class _AccessMessage(Construct):
         ConfigOpcode: ConfigMessage,
         DebugOpcode: DebugMessage,
         GatewayConfigServerOpcode: GatewayConfigMessage,
-        GenericPropertyOpcode: GenericPropertyMessage,
         GenericOnOffOpcode: GenericOnOffMessage,
         GenericBatteryOpcode: GenericBatteryMessage,
         GenericLevelOpcode: GenericLevelMessage,
@@ -55,6 +54,7 @@ class _AccessMessage(Construct):
         TimeOpcode: TimeMessage,
         DebugV2Opcode: DebugV2Message,
         RRuleSchedulerOpcode: RRuleSchedulerMessage,
+        GenericPropertyOpcode: GenericPropertyMessage,
         EmergencyLightingOpcode: EmergencyLightingMessage,
         EmergencyLightingTestOpcode: EmergencyLightingTestMessage,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bluetooth-mesh-messages"
-version = "0.9.3"
+version = "0.9.4"
 readme = "README.rst"
 authors = [
     { name = "Michał Lowas-Rzechonek", email = "michal.lowas-rzechonek@silvair.com" },


### PR DESCRIPTION
This is necessary so that Capnproto binary encoding of messages that are already in use is not affected by introduction of Generic Property messages.
